### PR TITLE
feat: add --formula option to install only formulas

### DIFF
--- a/script/install-homebrew.sh
+++ b/script/install-homebrew.sh
@@ -10,6 +10,12 @@ if [[ "$1" == "--cask" ]]; then
     INSTALL_CASKS=true
 fi
 
+# If --formula is specified, only install formulas
+if [[ "$1" == "--formula" ]]; then
+    INSTALL_FORMULAS=true
+    INSTALL_CASKS=false
+fi
+
 # Check for Homebrew installation and if not exist install 
 if test ! $(which brew); then
     echo "[INFO] Installing homebrew..."


### PR DESCRIPTION
This PR adds support for a new `--formula` argument to the `install-homebrew.sh` script. 

Changes:
- Added a new command line argument `--formula` which when specified will only install formulas and skip cask installations
- The behavior is similar to the existing `--cask` option but for formulas instead
- Default behavior (when no arguments are provided) remains unchanged

Usage:
```bash
# Install only formulas
./script/install-homebrew.sh --formula

# Install only casks (existing behavior)
./script/install-homebrew.sh --cask

# Install both (default behavior)
./script/install-homebrew.sh
```