### PR TITLE
Add --help option to install-homebrew.sh

### DIFF
--- a/script/install-homebrew.sh
+++ b/script/install-homebrew.sh
@@ -1,8 +1,27 @@
 #!/bin/bash
 
+# Help function to display usage
+show_help() {
+    echo "Usage: $(basename "$0") [OPTION]"
+    echo "Install Homebrew packages and casks."
+    echo
+    echo "Options:"
+    echo "  --help     Display this help message"
+    echo "  --cask     Only install Cask packages"
+    echo "  --formula  Only install Formula packages"
+    echo
+    echo "Without options, both formulas and casks will be installed."
+}
+
 # Parse command line arguments
 INSTALL_FORMULAS=true
 INSTALL_CASKS=true
+
+# Check for help argument first
+if [[ "$1" == "--help" ]]; then
+    show_help
+    exit 0
+fi
 
 # If --cask is specified, only install casks
 if [[ "$1" == "--cask" ]]; then


### PR DESCRIPTION
This PR adds a help option to the Homebrew installation script to improve usability.

### Changes
- Add `show_help()` function to display usage information
- Add `--help` argument handling that shows available options
- Improve documentation of command-line options
- Maintain existing `--cask` and `--formula` functionality

### Usage
The script now supports the following options:
```bash
./script/install-homebrew.sh --help     # Show usage information
./script/install-homebrew.sh --cask     # Only install casks
./script/install-homebrew.sh --formula  # Only install formulas
./script/install-homebrew.sh           # Install both (default)
```